### PR TITLE
WSL2 support

### DIFF
--- a/src/aivisspeech-client.ts
+++ b/src/aivisspeech-client.ts
@@ -98,7 +98,7 @@ export class AivisSpeechClient {
           args = [tempFilePath];
           break;
         case 'linux':
-          command = 'aplay';
+          command = 'paplay';
           args = [tempFilePath];
           break;
         case 'win32': // Windows

--- a/src/aivisspeech-client.ts
+++ b/src/aivisspeech-client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import { spawnSync } from 'child_process';
 
 export interface SpeakOptions {
   text: string;
@@ -97,10 +98,23 @@ export class AivisSpeechClient {
           command = 'afplay';
           args = [tempFilePath];
           break;
-        case 'linux':
-          command = 'paplay';
+        case 'linux': {
+          const chooseCmd = () => {
+            // WSL環境で再生するにはpaplayコマンドを使用する必要があるため、paplayを優先。なければaplayを使用
+            if (spawnSync('which', ['paplay']).status === 0) {
+              return 'paplay';
+            }
+            if (spawnSync('which', ['aplay']).status === 0) {
+              return 'aplay';
+            }
+            throw new Error(
+              '音声再生コマンド(paplay または aplay)が見つかりません'
+            );
+          };
+          command = chooseCmd();
           args = [tempFilePath];
           break;
+        }
         case 'win32': // Windows
           command = 'powershell';
           args = [


### PR DESCRIPTION
## Summary

### 検証した環境

$ wsl --version
WSL バージョン: 2.5.9.0
カーネル バージョン: 6.6.87.2-1
WSLg バージョン: 1.0.66
MSRDC バージョン: 1.2.6074
Direct3D バージョン: 1.611.1-81528511
DXCore バージョン: 10.0.26100.1-240331-1435.ge-release
Windows バージョン: 10.0.26100.4351

### 前提

- Windows上でAIVISSPEECHを起動し、localhost:10101でlistenしている
- WSL2上で本MCPのMCPサーバーを立てて、エージェントから実行したい

この時、MCPサーバーの実行環境としてはLinux OSのため、aplayコマンドが実行されるが、その場合本MCPのレスポンスとして
> 音声再生に失敗しました。終了コード: 1

が返ってきてしまう。

### 検証事項

aplayコマンドをWSL上で実行してみた結果が以下

> $ ffmpeg -f lavfi -i "sine=frequency=440:duration=5" -c:a pcm_s16le -ar 44100 -ac 2 output.wav
> $ aplay test.wav
> ALSA lib confmisc.c:855:(parse_card) cannot find card '0'
> ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_card_inum returned error: そのようなファイルやディレクトリはありません
> ALSA lib confmisc.c:422:(snd_func_concat) error evaluating strings
> ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_concat returned error: そのようなファイルやディレクトリはありません
> ALSA lib confmisc.c:1334:(snd_func_refer) error evaluating name
> ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_refer returned error: そのようなファイルやディレクトリはありません
> ALSA lib conf.c:5701:(snd_config_expand) Evaluate error: そのようなファイルやディレクトリはありません
> ALSA lib pcm.c:2664:(snd_pcm_open_noupdate) Unknown PCM default
> aplay: main:831: オーディオオープンエラー そのようなファイルやディレクトリはありません

つまり、そもそもWSL上でaplayコマンドで音声を出力することはできない。
これはWSLがWindows上のオーディオエンジンをネイティブに利用できないことから考えても自然。

この解決法として、[WSLg](https://github.com/microsoft/wslg)が考えられる。
具体的には、WSLg によってWindows 側のPulseAudioサーバーが自動的に起動・公開されるため、PulseAudioプロトコルを用いて再生するようにすればよい。
PulseAudioプロトコルを用いるため、aplayコマンドの代わりに[paplayコマンド](https://linux.die.net/man/1/paplay)を使用するようにすると、wavファイルの再生がWSL上で可能になり、本MCPをWSL上で使用することが可能となった。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * Linux環境での音声再生コマンドの選択を改善し、WSL環境などでより適切なコマンドが自動的に使用されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->